### PR TITLE
cuda-nvprof v12.9.79

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -25,7 +25,7 @@ set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
 
 echo Downloading micromamba %MICROMAMBA_VERSION%
 if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
-certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('%MICROMAMBA_URL%', '%MICROMAMBA_EXE%')"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 echo Creating environment

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+#   - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cuda-nvprof" %}
-{% set version = "12.9.19" %}
+{% set version = "12.9.79" %}
 {% set cuda_version = "12.9" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
@@ -16,8 +16,8 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvprof/{{ platform }}/cuda_nvprof-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 244de279776251636039ff93dfe4abca41a953f38586c824b188376cb21d65c3  # [linux64]
-  sha256: 21fe0f7ce782ed8fce3bec74234f779f74330fbdc8ca007b5f734ef7d00e708c  # [win]
+  sha256: 8d8d1a9004710bad8d7a653769f088064b0285a06a80b46c4da7598115a0c6a2  # [linux64]
+  sha256: 81aefd12ab0a24f88feee10303b814fcf21887b3947d5e73523ed14338ef4e2b  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cuda-nvprof" %}
-{% set version = "12.8.90" %}
-{% set cuda_version = "12.8" %}
+{% set version = "12.9.19" %}
+{% set cuda_version = "12.9" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "windows-x86_64" %}  # [win]
@@ -16,11 +16,11 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvprof/{{ platform }}/cuda_nvprof-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 66d5e0e498a50f1f240d80aa0a0577709b39aa98e2a71a578bc3bc271b9ad131  # [linux64]
-  sha256: 38405e49b0956972e7f3c4a6cd3a06ab3c0547a7bd73ce55510346e4a1063daf  # [win]
+  sha256: 244de279776251636039ff93dfe4abca41a953f38586c824b188376cb21d65c3  # [linux64]
+  sha256: 21fe0f7ce782ed8fce3bec74234f779f74330fbdc8ca007b5f734ef7d00e708c  # [win]
 
 build:
-  number: 1
+  number: 0
   binary_relocation: false
   skip: true  # [osx or aarch64 or ppc64le]
   missing_dso_whitelist:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,10 +2,8 @@
 {% set version = "12.9.79" %}
 {% set cuda_version = "12.9" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
-{% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "windows-x86_64" %}  # [win]
 {% set target_name = "x86_64-linux" %}  # [linux64]
-{% set target_name = "ppc64le-linux" %}  # [ppc64le]
 {% set target_name = "sbsa-linux" %}  # [aarch64]
 {% set extension = "tar.xz" %}  # [not win]
 {% set extension = "zip" %}  # [win]
@@ -22,12 +20,11 @@ source:
 build:
   number: 0
   binary_relocation: false
-  skip: true  # [osx or aarch64 or ppc64le]
+  skip: true  # [osx or aarch64]
   missing_dso_whitelist:
     # This is a driver file, might be able to use cuda-compat to remove this
     - '*/libcuda.so.1'  # [linux]
     - '*/libgcc_s.so.1'  # [linux]
-    - '*/libstdc++.so.6'  # [ppc64le]
     - '*/nvcuda.dll'    # [win]
 
 requirements:
@@ -39,7 +36,9 @@ requirements:
     - cf-nvidia-tools 1  # [linux]
   host:
     - cuda-version {{ cuda_version }}
-    - cuda-cupti
+    # The following libraries need to be pinned to the exact version due to dependency resolver issues
+    # It would be unsafe to pick a different version (versions are specific to CTK 12.9)
+    - cuda-cupti ==12.9.79
   run:
     - {{ pin_compatible("cuda-version", max_pin="x.x") }}
     - cuda-cupti
@@ -74,11 +73,13 @@ about:
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: Tool for collecting and viewing CUDA application profiling data
   description: |
     Tool for collecting and viewing CUDA application profiling data from
     the command-line.
   doc_url: https://docs.nvidia.com/cuda/index.html
+  dev_url: https://docs.nvidia.com/cuda/index.html
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
cuda-nvprof 12.9.79

**Destination channel:** defaults

### Links

- [PKG-12789](https://anaconda.atlassian.net/browse/PKG-12789) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Synchronize with upstream feedstock's `main` branch
- Added `abs.yaml` for possible use of staging channels in future builds


[PKG-12789]: https://anaconda.atlassian.net/browse/PKG-12789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ